### PR TITLE
Fix some consistency issues with notification placement and punctuation

### DIFF
--- a/src/content/docs/components/accordion.mdx
+++ b/src/content/docs/components/accordion.mdx
@@ -27,10 +27,6 @@ Learn how to implement the Accordion component in your project, from basic usage
 
 ### Basic
 
-<Aside type="tip" title="Exclusive behavior">
-  Use the `name` prop to create mutually exclusive accordion groups where only one item can be open at a time.
-</Aside>
-
 ```astro ins={7}
 ---
 import { Accordion, AccordionItem } from 'accessible-astro-components'
@@ -52,9 +48,13 @@ import { Accordion, AccordionItem } from 'accessible-astro-components'
 </Accordion>
 ```
 
+<Aside type="tip" title="Exclusive behavior">
+  Use the `name` prop to create mutually exclusive accordion groups where only one item can be open at a time.
+</Aside>
+
 ### Variants
 
-The AccordionItem component offers flexibility in its visual presentation through two distinct styles, allowing you to choose the one that best fits your design needs.
+The AccordionItem component offers flexibility in its visual presentation through two distinct styles using the `variant` prop, allowing you to choose the one that best fits your design needs.
 
 ```astro
 <Accordion>

--- a/src/content/docs/components/breadcrumbs.mdx
+++ b/src/content/docs/components/breadcrumbs.mdx
@@ -28,10 +28,6 @@ Learn how to implement the Breadcrumbs component in your project, from basic usa
 
 ### Basic
 
-<Aside type="tip" title="Current page">
-  Use the `currentPage` prop to indicate the current page in the breadcrumb trail. This will render it as a `<span>` instead of a link and add the appropriate ARIA attributes.
-</Aside>
-
 ```astro
 ---
 import { Breadcrumbs, BreadcrumbsItem } from 'accessible-astro-components'
@@ -43,6 +39,10 @@ import { Breadcrumbs, BreadcrumbsItem } from 'accessible-astro-components'
   <BreadcrumbsItem label="Current Page" currentPage={true} />
 </Breadcrumbs>
 ```
+
+<Aside type="tip" title="Current page">
+  Use the `currentPage` prop to indicate the current page in the breadcrumb trail. This will render it as a `<span>` instead of a link and add the appropriate ARIA attributes.
+</Aside>
 
 ### Variants
 

--- a/src/content/docs/components/card.mdx
+++ b/src/content/docs/components/card.mdx
@@ -22,10 +22,6 @@ The Card component provides a versatile container for displaying related content
 
 ## Usage
 
-<Aside type="tip" title="Flexible content">
-  The Card component accepts any content through its default slot, allowing for flexible layouts while maintaining accessibility.
-</Aside>
-
 ```astro
 ---
 import { Card } from 'accessible-astro-components'
@@ -39,6 +35,10 @@ import { Card } from 'accessible-astro-components'
   <p>This is the card content that can include any HTML.</p>
 </Card>
 ```
+
+<Aside type="tip" title="Flexible content">
+  The Card component accepts any content through its default slot, allowing for flexible layouts while maintaining accessibility.
+</Aside>
 
 ## Props
 
@@ -56,7 +56,7 @@ import { Card } from 'accessible-astro-components'
 
 - Uses semantic HTML structure
 - Proper heading hierarchy with configurable levels
-- Images include proper alt text support
+- Image alt attributes are properly empty for decorative images
 - Links are properly structured for keyboard navigation
 - Focus states are clearly visible
 - Color contrast meets WCAG guidelines

--- a/src/content/docs/components/dark-mode.mdx
+++ b/src/content/docs/components/dark-mode.mdx
@@ -22,9 +22,6 @@ The Dark mode component provides a toggle for switching between light and dark c
 
 ## Usage
 
-<Aside type="tip" title="Initial mode">
-  Use the `initialMode` prop to set the default color scheme. Options are 'light', 'dark', or 'auto' (uses system preference).
-</Aside>
 
 ```astro
 ---
@@ -40,6 +37,10 @@ import { DarkMode } from 'accessible-astro-components'
   <Icon name="ion:bulb-outline" slot="dark" />
 </DarkMode>
 ```
+
+<Aside type="tip" title="Initial mode">
+  Use the `initialMode` prop to set the default color scheme. Options are 'light', 'dark', or 'auto' (uses system preference).
+</Aside>
 
 ## Props
 

--- a/src/content/docs/components/media.mdx
+++ b/src/content/docs/components/media.mdx
@@ -33,10 +33,6 @@ Learn how to implement the Media component in your project, from basic usage to 
 
 ### Basic
 
-<Aside type="tip" title="Loading strategy">
-  Use the `loading` and `fetchpriority` props to optimize the loading behavior of above-the-fold images.
-</Aside>
-
 ```astro
 ---
 import { Media } from 'accessible-astro-components'
@@ -48,6 +44,10 @@ import { Media } from 'accessible-astro-components'
   ratio="16:9"
 />
 ```
+
+<Aside type="tip" title="Loading strategy">
+  Use the `loading` and `fetchpriority` props to optimize the loading behavior of above-the-fold images.
+</Aside>
 
 ### With Custom Loading
 

--- a/src/content/docs/components/modal.mdx
+++ b/src/content/docs/components/modal.mdx
@@ -11,10 +11,6 @@ import Modal from '../../../components/Modal.astro';
 
 The Modal component provides a dialog window that appears on top of the main content. It uses the native HTML `<dialog>` element for built-in accessibility features and includes smooth transitions, focus management, and keyboard interactions.
 
-<Aside type="caution" title="Use sparingly">
-  Modals can be disruptive to the user experience. Only use them when you need the user's immediate attention or action.
-</Aside>
-
 <Aside type="note" title="View transitions">
   The component automatically handles Astro's view transitions.
 </Aside>
@@ -30,6 +26,10 @@ The Modal component is perfect for situations where you need to capture user att
 - Terms and conditions
 - Cookie consent notices
 - User feedback prompts
+
+<Aside type="caution" title="Use sparingly">
+  Modals can be disruptive to the user experience. Only use them when you need the user's immediate attention or action.
+</Aside>
 
 ## Usage
 

--- a/src/content/docs/components/notification.mdx
+++ b/src/content/docs/components/notification.mdx
@@ -47,7 +47,7 @@ import { Icon } from 'astro-icon/components'
 
 <!-- Basic notification -->
 <Notification>
-  <p><strong>Message:</strong> This is a notification!</p>
+  <p><strong>Message:</strong> This is a notification.</p>
 </Notification>
 
 <!-- With icon and type -->
@@ -198,7 +198,7 @@ See the Notification component in action with these practical examples:
 
 <div class="not-content">
   <Notification>
-    <p><strong>Message:</strong> This is a notification!</p>
+    <p><strong>Message:</strong> This is a notification.</p>
   </Notification>
 </div>
 

--- a/src/content/docs/components/pagination.mdx
+++ b/src/content/docs/components/pagination.mdx
@@ -44,17 +44,18 @@ import { Pagination } from 'accessible-astro-components'
   totalPages="12"
   ariaLabel="Blog navigation"
 />
+
+<Pagination
+  currentPage="5"
+  totalPages="12"
+  renderProgress={({ currentPage, totalPages }) => 
+    `${currentPage} of ${totalPages} pages`
+  }
+/>
 ```
 
 <Aside type="note" title="Custom progress text">
-  You can customize the progress text using the `renderProgress` prop:
-  ```astro
-  <Pagination
-    renderProgress={({ currentPage, totalPages }) => 
-      `${currentPage} of ${totalPages} pages`
-    }
-  />
-  ```
+  You can customize the progress text using the `renderProgress` prop.
 </Aside>
 
 ## Props

--- a/src/content/docs/components/skip-links.mdx
+++ b/src/content/docs/components/skip-links.mdx
@@ -44,6 +44,10 @@ import { SkipLinks } from 'accessible-astro-components'
 </main>
 ```
 
+<Aside type="tip" title="Best practice">
+  Place the Skip Links component as the first focusable element on your page, before any navigation or content.
+</Aside>
+
 ## Props
 
 <div class="props-wrapper">
@@ -66,10 +70,6 @@ The Skip Links component prioritizes accessibility through several features:
 - Proper focus management
 - Fallback to `<h1>` if main content ID is missing
 - Console warning if neither target is found
-
-<Aside type="tip" title="Best practice">
-  Place the Skip Links component as the first focusable element on your page, before any navigation or content.
-</Aside>
 
 ## Styling
 

--- a/src/content/docs/components/tabs.mdx
+++ b/src/content/docs/components/tabs.mdx
@@ -29,10 +29,6 @@ Use the Tabs component when you need to:
 
 The Tabs component consists of four parts: the container, list wrapper, individual tabs, and their corresponding panels.
 
-<Aside type="tip" title="Progressive enhancement">
-  The component uses JavaScript for enhanced functionality but maintains a logical structure even without it.
-</Aside>
-
 ```astro
 ---
 import { Tabs, TabsList, TabsTab, TabsPanel } from 'accessible-astro-components'
@@ -60,6 +56,10 @@ import { Tabs, TabsList, TabsTab, TabsPanel } from 'accessible-astro-components'
 </Tabs>
 ```
 
+<Aside type="tip" title="Progressive enhancement">
+  The component uses JavaScript for enhanced functionality but maintains a logical structure even without it.
+</Aside>
+
 ## Props
 
 Each component in the Tabs system accepts specific props:
@@ -67,12 +67,12 @@ Each component in the Tabs system accepts specific props:
 ### Tabs
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `class` | `string` | `undefined` | Additional CSS classes to apply |
+| `class` | `string` | `''` | Additional CSS classes to apply |
 
 ### TabsList
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `class` | `string` | `undefined` | Additional CSS classes to apply |
+| `class` | `string` | `''` | Additional CSS classes to apply |
 
 ### TabsTab
 | Prop | Type | Default | Description |
@@ -80,7 +80,7 @@ Each component in the Tabs system accepts specific props:
 | `id` | `string` | Required | Unique identifier for the tab |
 | `controls` | `string` | Required | ID of the panel this tab controls |
 | `selected` | `boolean` | `false` | Whether this tab is initially selected |
-| `class` | `string` | `undefined` | Additional CSS classes to apply |
+| `class` | `string` | `''` | Additional CSS classes to apply |
 
 ### TabsPanel
 | Prop | Type | Default | Description |
@@ -88,7 +88,7 @@ Each component in the Tabs system accepts specific props:
 | `id` | `string` | Required | Unique identifier for the panel |
 | `labelledby` | `string` | Required | ID of the tab that labels this panel |
 | `selected` | `boolean` | `false` | Whether this panel is initially visible |
-| `class` | `string` | `undefined` | Additional CSS classes to apply |
+| `class` | `string` | `''` | Additional CSS classes to apply |
 
 ## Accessibility features
 


### PR DESCRIPTION
Fixed some consistency issues on several component pages:

- accordion
- breadcrumbs
- card
- dark-mode
- media
- modal
- notification
- pagination
- skip-links
- tabs

Example:
![afbeelding](https://github.com/user-attachments/assets/82711036-a753-4546-8c9b-9e8b43e046e3)
